### PR TITLE
Added ability to provide optional arguments to the test suite being invoked

### DIFF
--- a/integrate/discover.py
+++ b/integrate/discover.py
@@ -68,10 +68,12 @@ class TestRunner(object):
         base_classes = {base for test_case in test_cases for base in test_case.__bases__}
         return [test_case for test_case in test_cases if test_case not in base_classes]
 
-    def run(self, only=None):
+    def run(self, args=None, only=None):
         "Run discovered tests, may be filtered with only="
         files = self._discover()
         test_cases = self._import(files)
+
+        print("Discover Test Args: {}".format( args ))
 
         tests = 0
         skipped = 0
@@ -83,7 +85,7 @@ class TestRunner(object):
             num_tests, num_failed, num_exfailed, num_skipped = test(
                 verbosity=self.verbosity,
                 checker=self.checker
-            ).run()
+            ).run(args)
             tests += num_tests
             skipped += num_skipped
             failed += num_failed

--- a/integrate/test.py
+++ b/integrate/test.py
@@ -116,12 +116,14 @@ class TestCase(object):
 
         return [name for name, func in tests]
 
-    def run(self):
+    def run(self, args=None):
         "Run the tests in this test case"
         self.results = {}
 
+        print("* Test Suite args: {}".format( args ))
+
         print("* Running test suite '{}'".format(self.__class__.__doc__))
-        self.setup_all()
+        self.setup_all(args=args)
 
         # collect tests
         possible_tests = inspect.getmembers(self, predicate=inspect.ismethod)


### PR DESCRIPTION
I have used the integrate framework for some time. In my work, I need to deploy and test the software application in multiple environments (development, integration, and production). Each of these environments requires different configuration parameters based on the environment, and I couldn't find a clean way to use the integrate framework 'out of the box' that allowed me to run the same test suite in each environment.

With this pull request, I have introduced an optional 'args' parameter that is passed to the setup_all() function within the test suite. I use this args parameter to pass the necessary configuration information to the test suite, allowing a single suite to be easily used to test in multiple environments.

I did not update the README, but can do so if you think that this behavior is worth integrating into the base distribution.